### PR TITLE
Added tmp dependency. A workaround until the true issue is resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "grunt-strip": "~0.2.1",
     "express": "latest",
+    "tmp": "0.0.23",
     "bower": "~1.2.6",
     "grunt": "~0.4.1",
     "grunt-shell": "~0.4.0",


### PR DESCRIPTION
See: https://github.com/bower/bower/pull/1403#issuecomment-48784169, which details the primary source of the issue. By placing an exact version of tmp in package.json, the build process no longer ends at:

bower **error**                    Arguments to path.join must be strings
