### PR TITLE
Fix Failing Builds - By pulling AngularJS version down to 1.2.x and added tmp dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,10 +25,10 @@
     "tests"
   ],
   "devDependencies": {
-    "angular": "~1.3.x",
-    "angular-route": "~1.3.x",
-    "angular-mocks": "~1.3.x",
-    "angular-scenario": "~1.3.x",
+    "angular": "~1.2.x",
+    "angular-route": "~1.2.x",
+    "angular-mocks": "~1.2.x",
+    "angular-scenario": "~1.2.x",
     "jquery": "~2.0.3",
     "angular-translate": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "grunt-jsbeautifier": "~0.2.3",
     "grunt-replace": "~0.5.1",
     "grunt-contrib-jshint": "~0.6.3",
-    "grunt-yui-compressor": "~0.3.0"
+    "grunt-yui-compressor": "~0.3.0",
+    "tmp": "0.0.23"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- AngularJS 1.3 seems to break the build - so changed versions in bower.json to ~1.2.x
- No tmp dependency defined in package.json - It **has to be 0.0.23** otherwise any higher and the build breaks
- Spec test "defaults to using the translate service, if available" is a test that doesn't seem to be working as intended. If translate is off, @facultymatt should it return back "Hello"?

This would resolve the build issues on Travis CI.
