### PR TITLE
Fixed double confirmation alert

### DIFF
--- a/src/unsavedChanges.js
+++ b/src/unsavedChanges.js
@@ -196,22 +196,28 @@ angular.module('unsavedChanges', ['resettable'])
 
             var eventsToWatchFor = unsavedWarningsConfig.routeEvent;
 
-            angular.forEach(eventsToWatchFor, function(aEvent) {
+            angular.forEach(eventsToWatchFor, function (aEvent) {
                 //calling this function later will unbind this, acting as $off()
-                var removeFn = $rootScope.$on(aEvent, function(event, next, current) {
+                var removeFn = $rootScope.$on(aEvent, function (event, next, current) {
                     unsavedWarningsConfig.log("user is moving with " + aEvent);
-                    // @todo this could be written a lot cleaner!
-                    if (!allFormsClean()) {
-                        unsavedWarningsConfig.log("a form is dirty");
-                        if (!confirm(unsavedWarningsConfig.navigateMessage)) {
-                            unsavedWarningsConfig.log("user wants to cancel leaving");
-                            event.preventDefault(); // user clicks cancel, wants to stay on page
+                    if (unsavedWarningsConfig.hasConfirmed) {
+                        unsavedWarningsConfig.log("user already confirmed, skipping confirmation for " + aEvent);
+                    }
+                    else {
+                        // @todo this could be written a lot cleaner!
+                        if (!allFormsClean()) {
+                            unsavedWarningsConfig.log("a form is dirty");
+                            if (!confirm(unsavedWarningsConfig.navigateMessage)) {
+                                unsavedWarningsConfig.log("user wants to cancel leaving");
+                                event.preventDefault(); // user clicks cancel, wants to stay on page
+                            } else {
+                                unsavedWarningsConfig.hasConfirmed = true;
+                                unsavedWarningsConfig.log("user doesn't care about loosing stuff");
+                                $rootScope.$broadcast('resetResettables');
+                            }
                         } else {
-                            unsavedWarningsConfig.log("user doesn't care about loosing stuff");
-                            $rootScope.$broadcast('resetResettables');
+                            unsavedWarningsConfig.log("all forms are clean");
                         }
-                    } else {
-                        unsavedWarningsConfig.log("all forms are clean");
                     }
 
                 });


### PR DESCRIPTION
When using ui-router version v0.3.1, the confirmation alert was appearing twice when doing a window.history.back(), once for $locationChangeStart and $stateChangeStart.